### PR TITLE
fix: ignore items with no trackname

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,8 +46,8 @@ function App() {
 
         do {
             result = await sdk.playlists.getPlaylistItems(match[1], 'DE', 'offset,limit,next,items(track(id,name,artists(name),album(release_date)))', limit, offset);
-            result.items = result.items.filter(item => item.track?.name);
-            items.push(...result.items);
+            const filteredItems = result.items.filter(item => item.track?.name);
+            items.push(...filteredItems);
             offset += result.limit;
         } while (result.next !== null);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ function App() {
 
         do {
             result = await sdk.playlists.getPlaylistItems(match[1], 'DE', 'offset,limit,next,items(track(id,name,artists(name),album(release_date)))', limit, offset);
+            result.items = result.items.filter(item => item.track?.name);
             items.push(...result.items);
             offset += result.limit;
         } while (result.next !== null);


### PR DESCRIPTION
Some tracks seems not to return a track name. 
This fix will filter these songs out